### PR TITLE
Complete overhaul for Python 2/3 compat

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,16 +1,27 @@
 Changelog
 =========
 
-1.1.5 (unreleased)
-------------------
+2.0.0b1 (unreleased)
+--------------------
 
 Breaking changes:
 
-- *add item here*
+- Drop support of Python 2.6
+  [jensens]
+
+- Deprecate ``renderMessage(message)``,
+  use stdlibs ``message.as_string()`` from ``email.message.Message`` class instead.
+  [jensens]
+
+- Newline handling in MIME-headers are now escaped explicit.
+  This follows RFC2822 section 3.2.2.
+  [jensens]
 
 New features:
 
-- *add item here*
+- Support for Python 3.
+  Also big code overhaul included.
+  [jensens]
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -1,68 +1,64 @@
 Introduction
 ============
 
-This package provides primitives for turning content objects described by
-``zope.schema`` fields into RFC (2)822 style messages, as managed by the
-Python standard library's ``email`` module.
+This package provides primitives for turning content objects described by ``zope.schema`` fields into RFC (2)822 style messages.
+It utilizes the Python standard library's ``email`` module.
 
 It consists of:
 
-* A marker interface ``IPrimaryField`` which can be used to indicate the
-  primary field of a schema. The primary field will be used as the message
-  body.
-* An interface ``IFieldMarshaler`` which describes marshalers that convert
-  to and from strings suitable for encoding into an RFC 2822 style message.
-  These are adapters on ``(context, field)``, where ``context`` is the content
-  object and ``field`` is the schema field instance.
-* Default implementations of ``IFieldMarshaler`` for the standard fields in
-  the ``zope.schema`` package.
-* Helper methods to construct messages from one or more schemata or a list of
-  fields, and to parse a message and update a context object accordingly.
+* A marker interface ``IPrimaryField`` which can be used to indicate the primary field of a schema.
+  The primary field will be used as the message body.
+  If there are more than one field marked as primary, the body is turned in a MIME multipart message.
+* An interface ``IFieldMarshaler`` which describes marshalers that convert to and from strings suitable for encoding into an RFC 2822 style message.
+  These are multi-adapters on ``(context, field)``.
+  ``context`` is the content object and ``field`` is the schema field instance.
+* Default implementations of ``IFieldMarshaler`` for the standard fields in the ``zope.schema`` package.
+* Helper methods to construct messages from one or more schemata or a list of fields, and to parse a message and update a context object accordingly.
 
-The helper methods are described by ``plone.rfc822.interfaces.IMessageAPI``,
-and are importable directly from the ``plone.rfc822`` package::
+The helper methods are described by ``plone.rfc822.interfaces.IMessageAPI``.
+They are importable directly from the ``plone.rfc822`` package::
 
     def constructMessageFromSchema(context, schema, charset='utf-8'):
         """Convenience method which calls ``constructMessage()`` with all the
         fields, in order, of the given schema interface
         """
-    
+
     def constructMessageFromSchemata(context, schemata, charset='utf-8'):
         """Convenience method which calls ``constructMessage()`` with all the
         fields, in order, of all the given schemata (a sequence of schema
         interfaces).
         """
-    
+
     def constructMessage(context, fields, charset='utf-8'):
         """Helper method to construct a message.
-    
+
         ``context`` is a content object.
-    
+
         ``fields`` is a sequence of (name, field) pairs for the fields which make
         up the message. This can be obtained from zope.schema.getFieldsInOrder,
         for example.
-    
+
         ``charset`` is the message charset.
-    
+
         The message body will be constructed from the primary field, i.e. the
         field which is marked with ``IPrimaryField``. If no such field exists,
         the message will have no body. If multiple fields exist, the message will
         be a multipart message. Otherwise, it will contain a scalar string
         payload.
-    
+
         A field will be ignored if ``(context, field)`` cannot be multi-adapted
         to ``IFieldMarshaler``, or if the ``marshal()`` method returns None.
         """
-    
+
     def renderMessage(message, mangleFromHeader=False):
         """Render a message to a string
         """
-        
+
     def initializeObjectFromSchema(context, schema, message, defaultCharset='utf-8'):
         """Convenience method which calls ``initializeObject()`` with all the
         fields, in order, of the given schema interface
         """
-    
+
     def initializeObjectFromSchemata(context, schemata, message, defaultCharset='utf-8'):
         """Convenience method which calls ``initializeObject()`` with all the
         fields in order, of all the given schemata (a sequence of schema
@@ -71,55 +67,46 @@ and are importable directly from the ``plone.rfc822`` package::
 
     def initializeObject(context, fields, message, defaultCharset='utf-8'):
         """Initialise an object from a message.
-    
+
         ``context`` is the content object to initialise.
-    
+
         ``fields`` is a sequence of (name, field) pairs for the fields which make
         up the message. This can be obtained from zope.schema.getFieldsInOrder,
         for example.
-    
+
         ``message`` is a ``Message`` object.
-    
+
         ``defaultCharset`` is the default character set to use.
-    
+
         If the message is a multipart message, the primary fields will be read
         in order.
         """
 
 The message format used adheres to the following rules:
 
-* All non-primary fields are represented as headers. The header name is taken
-  from the field name, and the value is an encoded string as returned by the
-  ``marshal()`` method of the appropriate ``IFieldMarshal`` multi-adapter.
+* All non-primary fields are represented as headers.
+  The header name is taken from the field name.
+  The value is an encoded string as returned by the ``marshal()`` method of the appropriate ``IFieldMarshal`` multi-adapter.
 * If no ``IFieldMarshaler`` adapter can be found, the header is ignored.
-* Similarly, if no fields are found for a given header when parsing a message,
-  the header is ignored.
-* If there is a single primary field, the message has a string payload, which
-  is the marshalled value of the primary field. In this case, the
-  ``Content-Type`` header of the message will be obtained from the primary
-  field's marshaler.
-* If there are multiple primary fields, each is encoded into its own message,
-  each with its own ``Content-Type`` header. The outer message will have a
-  content type of ``multipart/mixed`` and headers for other fields.
-* A ``ValueError`` error is raised if a message is being parsed which has
-  more or fewer parts than there are primary fields.
+* Similarly, if no fields are found for a given header when parsing a message, the header is ignored.
+* If there is a single primary field, the message has a string payload, which is the marshalled value of the primary field.
+  In this case, the ``Content-Type`` header of the message will be obtained from the primary field's marshaler.
+* If there are multiple primary fields, each is encoded into its own message, each with its own ``Content-Type`` header.
+  The outer message will have a content type of ``multipart/mixed`` and headers for other fields.
+* A ``ValueError`` error is raised if a message is being parsed which has more or fewer parts than there are primary fields.
 * Duplicate field names are allowed, and will be encoded as duplicate headers.
-  When parsing a message, there needs to be one field per header. That is, if
-  a message contains two headers with the name 'foo', the list of field name/
-  instance pairs passed to the ``initializeObject()`` method should contain
-  two pairs with the name 'foo'. The first field will be used for the first
-  header value, the second field will be used for the second header value.
+  When parsing a message, there needs to be one field per header.
+  That is, if a message contains two headers with the name 'foo',
+  the list of field name/ instance pairs passed to the ``initializeObject()`` method should contain two pairs with the name 'foo'.
+  The first field will be used for the first header value, the second field will be used for the second header value.
   If a third 'foo' header appears, it will be ignored.
-* Since message headers are always lowercase, field names will be matched
-  case-insensitively when parsing a message.
+* Since message headers are always lowercase, field names will be matched case-insensitively when parsing a message.
 
 Supermodel handler
 ------------------
 
-If ``plone.supermodel`` is installed, this package will register a namespace
-handler for the ``marshal`` namespace, with the URI
-``http://namespaces.plone.org/supermodel/marshal``. This can be used to mark
-a field as the primary field::
+If ``plone.supermodel`` is installed, this package  will register a namespace handler for the ``marshal`` namespace, with the URI ``http://namespaces.plone.org/supermodel/marshal``.
+This can be used to mark a field as the primary field::
 
     <model xmlns="http://namespaces.plone.org/supermodel/schema"
            xmlns:marshal="http://namespaces.plone.org/supermodel/marshal">
@@ -131,11 +118,32 @@ a field as the primary field::
     </model>
 
 ``plone.supermodel`` may be installed as a dependency using the extra
-``[supermodel]``, but this is probably only useful for running the tests. If
-the package is not installed, the handler will not be ignored.
+``[supermodel]``, but this is probably only useful for running the tests.
+If the package is not installed, the handler will not be ignored.
 
 License note
 ------------
 
-This package is released under the BSD license. Contributors, please do not
-add dependencies on GPL code.
+This package is released under the BSD license.
+Contributors, please do not add dependencies on GPL code.
+
+Issue tracker
+-------------
+
+Please report issues via the `Plone issue tracker`_.
+
+.. _`Plone issue tracker`: https://github.com/plone/plone.rfc822/issues
+
+Support
+-------
+
+Dexterity use questions may be answered via `Plone's support channels`_.
+
+.. _`Plone's support channels`: http://plone.org/support
+
+Contributing
+------------
+
+Sources are at the `Plone code repository hosted at Github <https://github.com/plone/plone.rfc822>`_.
+
+Contributors please read the document `Process for Plone core's development <http://docs.plone.org/develop/plone-coredev/index.html>`_

--- a/plone/rfc822/configure.zcml
+++ b/plone/rfc822/configure.zcml
@@ -3,14 +3,23 @@
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="plone.rfc822">
-    
+
     <!-- Standard IFromUnicode marshaler -->
     <adapter factory=".defaultfields.UnicodeFieldMarshaler" />
-    
+
     <!-- Text, TextLine, Password, SourceText may be ASCII safe -->
     <adapter
-        for="* zope.schema.interfaces.IText"
+        for="* zope.schema.interfaces.INativeString"
         factory=".defaultfields.UnicodeValueFieldMarshaler"
+        />
+    <!-- ASCII Field marshaller -->
+    <adapter
+        for="* zope.schema.interfaces.IASCII"
+        factory=".defaultfields.ASCIISafeFieldMarshaler"
+        />
+    <adapter
+        for="* zope.schema.interfaces.IASCIILine"
+        factory=".defaultfields.ASCIISafeFieldMarshaler"
         />
 
     <!-- Bool and Choice omit to declare that they supports IFromUnicode in zope.schema 3.3 -->
@@ -22,7 +31,7 @@
         for="* zope.schema.interfaces.IChoice"
         factory=".defaultfields.UnicodeValueFieldMarshaler"
         />
-    
+
     <!-- Int, Float, and Decimal are ASCII safe -->
     <adapter
         for="* zope.schema.interfaces.IInt"
@@ -36,7 +45,7 @@
         for="* zope.schema.interfaces.IDecimal"
         factory=".defaultfields.ASCIISafeFieldMarshaler"
         />
-        
+
     <!-- Somehow this is necessary because these are in _bootstrapfields -->
     <adapter
         for="* zope.schema.Text"
@@ -54,13 +63,13 @@
         for="* zope.schema.Int"
         factory=".defaultfields.ASCIISafeFieldMarshaler"
         />
-        
+
     <adapter factory=".defaultfields.BytesFieldMarshaler" />
     <adapter factory=".defaultfields.DatetimeMarshaler" />
     <adapter factory=".defaultfields.DateMarshaler" />
     <adapter factory=".defaultfields.TimedeltaMarshaler" />
     <adapter factory=".defaultfields.CollectionMarshaler" />
-    
+
     <!-- Configure plone.supermodel handler if available -->
     <utility zcml:condition="installed plone.supermodel"
         factory=".supermodel.PrimaryFieldMetadataHandler"

--- a/plone/rfc822/configure.zcml
+++ b/plone/rfc822/configure.zcml
@@ -27,6 +27,13 @@
         for="* zope.schema.interfaces.IBool"
         factory=".defaultfields.ASCIISafeFieldMarshaler"
         />
+    <!-- We need this as a workaround for this issue:
+      https://github.com/zopefoundation/zope.schema/issues/80
+    -->
+    <adapter
+        for="* zope.schema._bootstrapfields.Bool"
+        factory=".defaultfields.ASCIISafeFieldMarshaler"
+        />
     <adapter
         for="* zope.schema.interfaces.IChoice"
         factory=".defaultfields.UnicodeValueFieldMarshaler"

--- a/plone/rfc822/defaultfields.py
+++ b/plone/rfc822/defaultfields.py
@@ -31,7 +31,6 @@ Unsupported by default:
 * InterfaceField - stores Interface
 * Dict - stores a dict
 """
-from __future__ import unicode_literals
 from plone.rfc822.interfaces import IFieldMarshaler
 from zope.component import adapter
 from zope.component import queryMultiAdapter

--- a/plone/rfc822/defaultfields.py
+++ b/plone/rfc822/defaultfields.py
@@ -31,9 +31,9 @@ Unsupported by default:
 * InterfaceField - stores Interface
 * Dict - stores a dict
 """
-
+from __future__ import unicode_literals
 from plone.rfc822.interfaces import IFieldMarshaler
-from zope.component import adapts
+from zope.component import adapter
 from zope.component import queryMultiAdapter
 from zope.interface import implementer
 from zope.interface import Interface
@@ -62,15 +62,15 @@ class BaseFieldMarshaler(object):
     def __init__(self, context, field):
         self.context = context
         self.field = field.bind(context)
-
         self.instance = context
         if field.interface is not None:
             self.instance = field.interface(context, context)
 
     def marshal(self, charset='utf-8', primary=False):
         value = self._query(_marker)
-        return None if value is _marker else \
-            self.encode(value, charset, primary)
+        return (
+            None if value is _marker else self.encode(value, charset, primary)
+        )
 
     def demarshal(
         self,
@@ -78,12 +78,15 @@ class BaseFieldMarshaler(object):
         message=None,
         charset='utf-8',
         contentType=None,
-        primary=False
+        primary=False,
     ):
-        fieldValue = self.field.missing_value
+
         if value:
             fieldValue = self.decode(
-                value, message, charset, contentType, primary)
+                value, message, charset, contentType, primary
+            )
+        else:
+            fieldValue = self.field.missing_value
         self._set(fieldValue)
 
     def encode(self, value, charset='utf-8', primary=False):
@@ -95,10 +98,11 @@ class BaseFieldMarshaler(object):
         message=None,
         charset='utf-8',
         contentType=None,
-        primary=False
+        primary=False,
     ):
-        raise ValueError("Demarshalling not implemented for %s" %
-                         repr(self.field))
+        raise ValueError(
+            'Demarshalling not implemented for %s' % repr(self.field)
+        )
 
     def getContentType(self):
         return None
@@ -115,17 +119,20 @@ class BaseFieldMarshaler(object):
         return self.field.query(self.instance, default)
 
     def _set(self, value):
+        if getattr(self.instance, 'marker', False):
+            print(self.field.__name__)
+            print(value)
+            print('-' * 5)
         try:
             self.field.set(self.instance, value)
         except TypeError as e:
             raise ValueError(e)
 
 
+@adapter(Interface, IFromUnicode)
 class UnicodeFieldMarshaler(BaseFieldMarshaler):
     """Default marshaler for fields that support IFromUnicode
     """
-
-    adapts(Interface, IFromUnicode)
 
     def encode(self, value, charset='utf-8', primary=False):
         if value is None:
@@ -141,9 +148,12 @@ class UnicodeFieldMarshaler(BaseFieldMarshaler):
         message=None,
         charset='utf-8',
         contentType=None,
-        primary=False
+        primary=False,
     ):
-        unicodeValue = value.decode(charset)
+        if isinstance(value, six.binary_type):
+            unicodeValue = value.decode(charset)
+        else:
+            unicodeValue = value
         try:
             return self.field.fromUnicode(unicodeValue)
         except Exception as e:
@@ -160,7 +170,8 @@ class UnicodeValueFieldMarshaler(UnicodeFieldMarshaler):
 
     def encode(self, value, charset='utf-8', primary=False):
         encoded = super(UnicodeValueFieldMarshaler, self).encode(
-            value, charset, primary)
+            value, charset, primary
+        )
         if not encoded or max(six.iterbytes(encoded)) < 128:
             self.ascii = True
         else:
@@ -179,12 +190,11 @@ class ASCIISafeFieldMarshaler(UnicodeFieldMarshaler):
         return None
 
 
+@adapter(Interface, IBytes)
 class BytesFieldMarshaler(BaseFieldMarshaler):
     """Default marshaler for IBytes fields and children. These store str
     objects, so we will attempt to encode them directly.
     """
-
-    adapts(Interface, IBytes)
 
     ascii = True
 
@@ -197,16 +207,15 @@ class BytesFieldMarshaler(BaseFieldMarshaler):
         message=None,
         charset='utf-8',
         contentType=None,
-        primary=False
+        primary=False,
     ):
         return value
 
 
+@adapter(Interface, IDatetime)
 class DatetimeMarshaler(BaseFieldMarshaler):
     """Marshaler for Python datetime values
     """
-
-    adapts(Interface, IDatetime)
 
     ascii = True
 
@@ -221,7 +230,7 @@ class DatetimeMarshaler(BaseFieldMarshaler):
         message=None,
         charset='utf-8',
         contentType=None,
-        primary=False
+        primary=False,
     ):
         unicodeValue = value.decode(charset)
         try:
@@ -230,6 +239,7 @@ class DatetimeMarshaler(BaseFieldMarshaler):
             raise ValueError(e)
 
 
+@adapter(Interface, IDate)
 class DateMarshaler(BaseFieldMarshaler):
     """Marshaler for Python date values.
 
@@ -237,8 +247,6 @@ class DateMarshaler(BaseFieldMarshaler):
     this does not seem to be capable of round-tripping values with time zone
     information.
     """
-
-    adapts(Interface, IDate)
 
     ascii = True
 
@@ -253,7 +261,7 @@ class DateMarshaler(BaseFieldMarshaler):
         message=None,
         charset='utf-8',
         contentType=None,
-        primary=False
+        primary=False,
     ):
         unicodeValue = value.decode(charset)
         try:
@@ -262,6 +270,7 @@ class DateMarshaler(BaseFieldMarshaler):
             raise ValueError(e)
 
 
+@adapter(Interface, ITimedelta)
 class TimedeltaMarshaler(BaseFieldMarshaler):
     """Marshaler for Python timedelta values
 
@@ -269,8 +278,6 @@ class TimedeltaMarshaler(BaseFieldMarshaler):
     this does not seem to be capable of round-tripping values with time zone
     information.
     """
-
-    adapts(Interface, ITimedelta)
 
     ascii = True
 
@@ -285,7 +292,7 @@ class TimedeltaMarshaler(BaseFieldMarshaler):
         message=None,
         charset='utf-8',
         contentType=None,
-        primary=False
+        primary=False,
     ):
         try:
             days, seconds, microseconds = [int(v) for v in value.split(":")]
@@ -294,17 +301,17 @@ class TimedeltaMarshaler(BaseFieldMarshaler):
             raise ValueError(e)
 
 
+@adapter(Interface, ICollection)
 class CollectionMarshaler(BaseFieldMarshaler):
     """Marshaler for collection values
     """
-
-    adapts(Interface, ICollection)
 
     ascii = False
 
     def getCharset(self, default='utf-8'):
         valueTypeMarshaler = queryMultiAdapter(
-            (self.context, self.field.value_type,), IFieldMarshaler)
+            (self.context, self.field.value_type), IFieldMarshaler
+        )
         if valueTypeMarshaler is None:
             return None
         return valueTypeMarshaler.getCharset(default)
@@ -314,7 +321,8 @@ class CollectionMarshaler(BaseFieldMarshaler):
             return None
 
         valueTypeMarshaler = queryMultiAdapter(
-            (self.context, self.field.value_type,), IFieldMarshaler)
+            (self.context, self.field.value_type), IFieldMarshaler
+        )
         if valueTypeMarshaler is None:
             return None
 
@@ -322,7 +330,8 @@ class CollectionMarshaler(BaseFieldMarshaler):
         value_lines = []
         for item in value:
             marshaledValue = valueTypeMarshaler.encode(
-                item, charset=charset, primary=primary)
+                item, charset=charset, primary=primary
+            )
             if marshaledValue is None:
                 marshaledValue = ''
             value_lines.append(marshaledValue)
@@ -330,8 +339,10 @@ class CollectionMarshaler(BaseFieldMarshaler):
                 ascii = False
 
         self.ascii = ascii
-
-        return '||'.join(value_lines)
+        if value_lines and isinstance(value_lines[0], six.binary_type):
+            return b'||'.join(value_lines)
+        else:
+            return '||'.join(value_lines)
 
     def decode(
         self,
@@ -339,22 +350,30 @@ class CollectionMarshaler(BaseFieldMarshaler):
         message=None,
         charset='utf-8',
         contentType=None,
-        primary=False
+        primary=False,
     ):
         valueTypeMarshaler = queryMultiAdapter(
-            (self.context, self.field.value_type,), IFieldMarshaler)
+            (self.context, self.field.value_type), IFieldMarshaler
+        )
         if valueTypeMarshaler is None:
-            raise ValueError("Cannot demarshal value type %s" %
-                             repr(self.field.value_type))
+            raise ValueError(
+                'Cannot demarshal value type %s' % repr(self.field.value_type)
+            )
 
         listValue = []
-
-        for line in value.split('||'):
-            listValue.append(valueTypeMarshaler.decode(
-                line, message, charset, contentType, primary))
+        if isinstance(value, six.binary_type):
+            lines = value.split(b'||')
+        else:
+            lines = value.split('||')
+        for line in lines:
+            listValue.append(
+                valueTypeMarshaler.decode(
+                    line, message, charset, contentType, primary
+                )
+            )
 
         sequenceType = self.field._type
-        if isinstance(sequenceType, (list, tuple,)):
+        if isinstance(sequenceType, (list, tuple)):
             sequenceType = sequenceType[-1]
 
         return sequenceType(listValue)

--- a/plone/rfc822/defaultfields.py
+++ b/plone/rfc822/defaultfields.py
@@ -231,9 +231,10 @@ class DatetimeMarshaler(BaseFieldMarshaler):
         contentType=None,
         primary=False,
     ):
-        unicodeValue = value.decode(charset)
+        if isinstance(value, six.binary_type):
+            value = value.decode(charset)
         try:
-            return dateutil.parser.parse(unicodeValue)
+            return dateutil.parser.parse(value)
         except Exception as e:
             raise ValueError(e)
 

--- a/plone/rfc822/fields.rst
+++ b/plone/rfc822/fields.rst
@@ -491,8 +491,8 @@ Timedelta
     >>> marshaler = getMultiAdapter((t, ITestContent['_timedelta']), IFieldMarshaler)
     >>> marshaler.marshal()
     '3:4:5'
-    >>> marshaler.decode('3:4:5')
-    datetime.timedelta(3, 4, 5)
+    >>> marshaler.decode('3:4:5') == datetime.timedelta(3, 4, 5)
+    True
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8') is None

--- a/plone/rfc822/fields.rst
+++ b/plone/rfc822/fields.rst
@@ -3,7 +3,7 @@ Field marshaler tests
 
 This test exercises the various standard field marshalers.
 
-First, we load the package's configuration:
+First, we load the package's configuration::
 
     >>> configuration = b"""\
     ... <configure
@@ -23,7 +23,7 @@ First, we load the package's configuration:
     >>> xmlconfig.xmlconfig(BytesIO(configuration))
 
 Next, we'll create an interface which contains an instance of every field
-we support.
+we support::
 
     >>> from zope.interface import Interface
     >>> from zope import schema
@@ -58,7 +58,7 @@ we support.
     ...     _set = schema.Set(value_type=schema.Bool())
     ...     _frozenset = schema.FrozenSet(value_type=schema.Timedelta())
 
-This interface is implemented by a the following class:
+This interface is implemented by a the following class::
 
     >>> from decimal import Decimal
     >>> from zope.interface import implementer
@@ -74,10 +74,10 @@ This interface is implemented by a the following class:
     ...     _password2 = u"password" # ascii safe
     ...     _bytes = 'bytes'
     ...     _bytesLine = 'bytesline'
-    ...     _ascii = 'ascii'
-    ...     _asciiLine = 'asciiline'
-    ...     _uri = 'http://plone.org'
-    ...     _id = 'some.id'
+    ...     _ascii = u'ascii'
+    ...     _asciiLine = u'asciiline'
+    ...     _uri = u'http://plone.org'
+    ...     _id = u'some.id'
     ...     _dottedName = 'dotted.name'
     ...     _bool = True
     ...     _int = long(-10) if six.PY2 else -10
@@ -96,7 +96,7 @@ This interface is implemented by a the following class:
     >>> t = TestContent()
 
 We can now look up the marshaler for each one and test the marshalling and
-extraction methods.
+extraction methods::
 
     >>> from zope.component import getMultiAdapter
     >>> from plone.rfc822.interfaces import IFieldMarshaler
@@ -113,11 +113,13 @@ Notes:
 Text
 ----
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_text']), IFieldMarshaler)
     >>> marshaler.marshal()
-    b'text\xc3\x98'
+    'text\xc3\x98'
     >>> marshaler.decode(b'text\xc3\x98')
-    u'text\xd8'
+    'text\xd8'
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8')
@@ -126,13 +128,13 @@ Text
     False
 
 Text field types and derivatives will return True for the ``ascii`` property
-if the field value is within the ascii range.
+if the field value is within the ascii range::
 
     >>> marshaler = getMultiAdapter((t, ITestContent['_text2']), IFieldMarshaler)
     >>> marshaler.marshal()
-    b'text'
+    'text'
     >>> marshaler.decode(b'text\xc3\x98')
-    u'text\xd8'
+    'text\xd8'
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8')
@@ -143,11 +145,13 @@ if the field value is within the ascii range.
 TextLine
 --------
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_textLine']), IFieldMarshaler)
     >>> marshaler.marshal()
-    b'textline\xc3\x98'
+    'textline\xc3\x98'
     >>> marshaler.decode(b'textline\xc3\x98')
-    u'textline\xd8'
+    'textline\xd8'
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8')
@@ -158,11 +162,13 @@ TextLine
 Text field types and derivatives will return True for the ``ascii`` property
 if the field value is within the ascii range.
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_textLine2']), IFieldMarshaler)
     >>> marshaler.marshal()
-    b'textline'
+    'textline'
     >>> marshaler.decode(b'textline\xc3\x98')
-    u'textline\xd8'
+    'textline\xd8'
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8')
@@ -173,11 +179,13 @@ if the field value is within the ascii range.
 Password
 --------
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_password']), IFieldMarshaler)
     >>> marshaler.marshal()
-    b'password\xc3\x98'
+    'password\xc3\x98'
     >>> marshaler.decode(b'password\xc3\x98')
-    u'password\xd8'
+    'password\xd8'
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8')
@@ -188,11 +196,13 @@ Password
 Text field types and derivatives will return True for the ``ascii`` property
 if the field value is within the ascii range.
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_password2']), IFieldMarshaler)
     >>> marshaler.marshal()
-    b'password'
+    'password'
     >>> marshaler.decode(b'password\xc3\x98')
-    u'password\xd8'
+    'password\xd8'
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8')
@@ -203,11 +213,13 @@ if the field value is within the ascii range.
 Bytes
 -----
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_bytes']), IFieldMarshaler)
     >>> marshaler.marshal()
     'bytes'
     >>> marshaler.decode(b'bytes')
-    b'bytes'
+    'bytes'
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8') is None
@@ -218,11 +230,13 @@ Bytes
 BytesLine
 ---------
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_bytesLine']), IFieldMarshaler)
     >>> marshaler.marshal()
     'bytesline'
     >>> marshaler.decode(b'bytesline')
-    b'bytesline'
+    'bytesline'
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8') is None
@@ -233,9 +247,14 @@ BytesLine
 ASCII
 -----
 
+This is an ASCII field which is supposed to store text strings.
+Note: There is a BytesField which stores b'foo' binary string.
+
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_ascii']), IFieldMarshaler)
     >>> marshaler.marshal()
-    b'ascii'
+    'ascii'
     >>> marshaler.decode(b'ascii')
     'ascii'
     >>> marshaler.getContentType() is None
@@ -248,11 +267,13 @@ ASCII
 ASCIILine
 ---------
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_asciiLine']), IFieldMarshaler)
     >>> marshaler.marshal()
     'asciiline'
     >>> marshaler.decode(b'asciiline')
-    b'asciiline'
+    'asciiline'
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8') is None
@@ -263,6 +284,10 @@ ASCIILine
 URI
 ---
 
+An URI is in Python 2 based on unicode text, in Python 3 on bytes.
+
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_uri']), IFieldMarshaler)
     >>> marshaler.marshal()
     'http://plone.org'
@@ -270,7 +295,11 @@ URI
     'http://plone.org'
     >>> marshaler.getContentType() is None
     True
-    >>> marshaler.getCharset('utf-8') is None
+    >>> if six.PY2:
+    ...     expected = None  # its IBytes based
+    ... else:
+    ...     expected = 'utf-8'
+    >>> marshaler.getCharset('utf-8') == expected
     True
     >>> marshaler.ascii
     True
@@ -278,20 +307,28 @@ URI
 Id
 --
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_id']), IFieldMarshaler)
     >>> marshaler.marshal()
     'some.id'
     >>> marshaler.decode(b'some.id')
     'some.id'
-    >>> marshaler.getCharset('utf-8') is None
-    True
     >>> marshaler.getContentType() is None
+    True
+    >>> if six.PY2:
+    ...     expected = None  # its IBytes based
+    ... else:
+    ...     expected = 'utf-8'
+    >>> marshaler.getCharset('utf-8') == expected
     True
     >>> marshaler.ascii
     True
 
 DottedName
 ----------
+
+::
 
     >>> marshaler = getMultiAdapter((t, ITestContent['_dottedName']), IFieldMarshaler)
     >>> marshaler.marshal()
@@ -300,13 +337,19 @@ DottedName
     'dotted.name'
     >>> marshaler.getContentType() is None
     True
-    >>> marshaler.getCharset('utf-8') is None
+    >>> if six.PY2:
+    ...     expected = None  # its IBytes based
+    ... else:
+    ...     expected = 'utf-8'
+    >>> marshaler.getCharset('utf-8') == expected
     True
     >>> marshaler.ascii
     True
 
 Bool
 ----
+
+::
 
     >>> marshaler = getMultiAdapter((t, ITestContent['_bool']), IFieldMarshaler)
     >>> marshaler.marshal()
@@ -329,6 +372,8 @@ Bool
 Int
 ---
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_int']), IFieldMarshaler)
     >>> marshaler.marshal()
     '-10'
@@ -343,6 +388,8 @@ Int
 
 Float
 -----
+
+::
 
     >>> marshaler = getMultiAdapter((t, ITestContent['_float']), IFieldMarshaler)
     >>> marshaler.marshal()
@@ -359,6 +406,8 @@ Float
 Decimal
 -------
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_decimal']), IFieldMarshaler)
     >>> marshaler.marshal()
     '5.0'
@@ -374,11 +423,13 @@ Decimal
 Choice
 ------
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_choice1']), IFieldMarshaler)
     >>> marshaler.marshal()
     'two'
     >>> marshaler.decode(b'one')
-    u'one'
+    'one'
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8')
@@ -390,7 +441,7 @@ Choice
     >>> marshaler.marshal()
     'two'
     >>> marshaler.decode(b'three')
-    u'three'
+    'three'
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8')
@@ -400,6 +451,8 @@ Choice
 
 Datetime
 --------
+
+::
 
     >>> marshaler = getMultiAdapter((t, ITestContent['_datetime']), IFieldMarshaler)
     >>> marshaler.marshal()
@@ -416,6 +469,8 @@ Datetime
 Date
 ----
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_date']), IFieldMarshaler)
     >>> marshaler.marshal()
     '2008-02-03'
@@ -431,10 +486,12 @@ Date
 Timedelta
 ---------
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_timedelta']), IFieldMarshaler)
     >>> marshaler.marshal()
     '3:4:5'
-    >>> marshaler.decode(b'3:4:5')
+    >>> marshaler.decode('3:4:5')
     datetime.timedelta(3, 4, 5)
     >>> marshaler.getContentType() is None
     True
@@ -446,11 +503,13 @@ Timedelta
 Tuple
 -----
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_tuple']), IFieldMarshaler)
     >>> marshaler.marshal()
     'one\xc3\x98||two'
     >>> marshaler.decode(b'one\xc3\x98||two')
-    (u'one\xd8', u'two')
+    ('one\xd8', 'two')
     >>> marshaler.getContentType() is None
     True
     >>> marshaler.getCharset('utf-8')
@@ -461,6 +520,8 @@ Tuple
 List
 ----
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_list']), IFieldMarshaler)
     >>> marshaler.marshal()
     'three||four'
@@ -468,6 +529,8 @@ List
     ['three', 'four']
     >>> marshaler.getContentType() is None
     True
+
+    ValueType of the list is ASCIILine!
     >>> marshaler.getCharset('utf-8') is None
     True
     >>> marshaler.ascii
@@ -475,6 +538,8 @@ List
 
 Set
 ---
+
+::
 
     >>> marshaler = getMultiAdapter((t, ITestContent['_set']), IFieldMarshaler)
     >>> marshaler.marshal() in (b'False||True', b'True||False')
@@ -491,10 +556,12 @@ Set
 Frozenset
 ---------
 
+::
+
     >>> marshaler = getMultiAdapter((t, ITestContent['_frozenset']), IFieldMarshaler)
-    >>> marshaler.marshal() in (b'3:4:5||5:4:3', b'5:4:3||3:4:5')
+    >>> marshaler.marshal() in ('3:4:5||5:4:3', '5:4:3||3:4:5')
     True
-    >>> marshaler.decode(b'3:4:5||5:4:3') == frozenset([datetime.timedelta(3, 4, 5), datetime.timedelta(5, 4, 3)])
+    >>> marshaler.decode('3:4:5||5:4:3') == frozenset([datetime.timedelta(3, 4, 5), datetime.timedelta(5, 4, 3)])
     True
     >>> marshaler.getContentType() is None
     True

--- a/plone/rfc822/interfaces.py
+++ b/plone/rfc822/interfaces.py
@@ -63,6 +63,8 @@ class IMessageAPI(Interface):
 
     def renderMessage(message, mangleFromHeader=False):
         """Render a message to a string
+
+        DEPRECATED. Use 'message.as_string()' instead.
         """
 
     def initializeObjectFromSchema(

--- a/plone/rfc822/message.rst
+++ b/plone/rfc822/message.rst
@@ -625,10 +625,5 @@ Technical both is fine.
     >>> content.description = "Test content\nwith newline difference"
     >>> msg = constructMessageFromSchema(content, ITestContent)
     >>> effective_output = msg.as_string()
-    >>> effective_output_line_2 = effective_output.split('\n')[1]
-    >>> if six.PY2:
-    ...     expected_output_line_2 = r"description: Test content\nwith newline difference"
-    ... else:
-    ...     expected_output_line_2 = r"description: =?utf-8?q?Test_content=5Cnwith_newline_difference?="
-    >>> effective_output_line_2 == expected_output_line_2
-    True
+    >>> effective_output.split('\n')[1]
+    'description: =?utf-8?q?Test_content=5Cnwith_newline_difference?='

--- a/plone/rfc822/message.rst
+++ b/plone/rfc822/message.rst
@@ -457,11 +457,11 @@ We can register a field marshaler for this field which will do the following:
     >>> from plone.rfc822.interfaces import IFieldMarshaler
     >>> from email.encoders import encode_base64
 
-    >>> from zope.component import adapts
+    >>> from zope.component import adapter
     >>> from plone.rfc822.defaultfields import BaseFieldMarshaler
 
-    >>> class FileFieldMarshaler(BaseFieldMarshaler):
-    ...     adapts(Interface, IFileField)
+    >>> @adapter(Interface, IFileField)
+    ... class FileFieldMarshaler(BaseFieldMarshaler):
     ...
     ...     ascii = False
     ...

--- a/plone/rfc822/supermodel.py
+++ b/plone/rfc822/supermodel.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 try:
     from plone.supermodel.interfaces import IFieldMetadataHandler
     HAVE_SUPERMODEL = True

--- a/plone/rfc822/supermodel.py
+++ b/plone/rfc822/supermodel.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 try:
     from plone.supermodel.interfaces import IFieldMetadataHandler
     HAVE_SUPERMODEL = True

--- a/plone/rfc822/tests.py
+++ b/plone/rfc822/tests.py
@@ -23,9 +23,9 @@ optionflags = doctest.ELLIPSIS | \
 class Py23DocChecker(doctest.OutputChecker):
     def check_output(self, want, got, optionflags):
         if six.PY2:
-            want = re.sub("b'(.*?)'", "'\\1'", want)
-        else:
-            want = re.sub('u"(.*?)"', '"\\1"', want)
+            got = re.sub("u'(.*?)'", "'\\1'", got)
+        if six.PY3:
+            got = re.sub("b'(.*?)'", "'\\1'", got)
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 

--- a/plone/rfc822/tests.py
+++ b/plone/rfc822/tests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from plone.rfc822._utils import safe_native_string
 from plone.testing import layered
 from plone.testing.zca import UNIT_TESTING
 
@@ -29,6 +30,14 @@ class Py23DocChecker(doctest.OutputChecker):
         return doctest.OutputChecker.check_output(self, want, got, optionflags)
 
 
+class TestUtils(unittest.TestCase):
+
+    def test_safe_native_string(self):
+        self.assertIsInstance(safe_native_string(b''), str)
+        self.assertIsInstance(safe_native_string(u''), str)
+        self.assertRaises(ValueError, safe_native_string, None)
+
+
 def test_suite():
 
     suite = unittest.TestSuite()
@@ -43,4 +52,5 @@ def test_suite():
         )
         for docfile in DOCFILES
     ])
+    suite.addTest(TestUtils('test_safe_native_string'))
     return suite

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: BSD License",
     ],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 import os
 
 
-version = '1.1.5.dev0'
+version = '2.0.0b1.dev0'
 
 setup(
     name='plone.rfc822',
@@ -19,17 +19,15 @@ setup(
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         "Framework :: Plone",
-        "Framework :: Plone :: 4.3",
-        "Framework :: Plone :: 5.0",
-        "Framework :: Plone :: 5.1",
+        # "Framework :: Plone :: 5.2",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: BSD License",
     ],
     keywords='zope schema rfc822',
-    author='Martin Aspeli',
+    author='Martin Aspeli and contributors',
     author_email='optilude@gmail.com',
     url='https://pypi.python.org/pypi/plone.rfc822',
     license='BSD',
@@ -39,14 +37,15 @@ setup(
     zip_safe=False,
     extras_require={
         'supermodel': ['plone.supermodel'],
-        'test': ['plone.testing'],
+        'test': ['plone.testing', 'plone.supermodel'],
     },
     install_requires=[
-        'setuptools',
-        'zope.schema',
-        'zope.component',
-        'zope.interface',
         'python-dateutil',
+        'setuptools',
+        'zope.component',
+        'zope.deprecation',
+        'zope.interface',
+        'zope.schema',
     ],
     entry_points="""
     """,


### PR DESCRIPTION
Includes refactoring b/c too many code broke the DRY rule which duplicated all the fixes needed. 

This is now Plone 5.2 only. 

Plone 5.1 and down sits already on a 1.x branch.